### PR TITLE
fix_codec_cant_encode_character_error

### DIFF
--- a/default.py
+++ b/default.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 import sys
+reload(sys);
+sys.setdefaultencoding("utf8")
 import urlparse
 
 import resources.lib.seventv as seventv


### PR DESCRIPTION
Hi Maven well done!

I had some problems reaching the live streams, kodi throws an error:
"'ascii' codec can't encode character u'\xa0' in position 111: ordinal not in range(128)"
seams to be an python bug. 
This PR  fixed the issue on all my Kodi boxes.



